### PR TITLE
(PE-26190) Add shared functions for pe-installer-shim

### DIFF
--- a/src/com/puppet/jenkinsSharedLibraries/Beaker.groovy
+++ b/src/com/puppet/jenkinsSharedLibraries/Beaker.groovy
@@ -1,0 +1,13 @@
+package com.puppet.jenkinsSharedLibraries
+
+class Beaker extends RvmEnvironment {
+    String beakerScript
+    Beaker(String rubyVersion, String beakerCommand) {
+        super(rubyVersion)
+        this.beakerScript = this.rvmCommand + """
+export BUNDLE_BIN=.bundle/bin
+export BUNDLE_PATH=.bundle/gems
+bundle exec beaker ${beakerCommand}
+"""
+    }
+}

--- a/src/com/puppet/jenkinsSharedLibraries/BeakerHostgenerator.groovy
+++ b/src/com/puppet/jenkinsSharedLibraries/BeakerHostgenerator.groovy
@@ -1,0 +1,22 @@
+package com.puppet.jenkinsSharedLibraries
+
+import groovy.transform.InheritConstructors
+
+class BeakerHostgenerator extends RvmEnvironment {
+    String hostgeneratorScript
+    BeakerHostgenerator(String rubyVersion,
+                        String peDir,
+                        String peVersion,
+                        String platform,
+                        String hypervisor,
+                        String hostfile=null) {
+        super(rubyVersion)
+        String hostgeneratorString = "bundle exec beaker-hostgenerator ${platform} --hypervisor ${hypervisor}\
+ --global-config forge_host=forge-aio01-petest.puppetlabs.com --pe_dir ${peDir} --pe_ver ${peVersion} >&1 | tee ${hostfile}"
+        this.hostgeneratorScript = this.rvmCommand + """
+export BUNDLE_BIN=.bundle/bin
+export BUNDLE_PATH=.bundle/gems
+${hostgeneratorString}
+"""
+    }
+}

--- a/src/com/puppet/jenkinsSharedLibraries/BundleExec.groovy
+++ b/src/com/puppet/jenkinsSharedLibraries/BundleExec.groovy
@@ -1,0 +1,14 @@
+package com.puppet.jenkinsSharedLibraries
+
+class BundleExec extends RvmEnvironment {
+    String bundleExec
+    BundleExec(String rubyVersion, String bundleExecCommand) {
+        super(rubyVersion)
+        this.bundleExec = this.rvmCommand + """
+export BUNDLE_BIN=.bundle/bin
+export BUNDLE_PATH=.bundle/gems
+bundle exec ${bundleExecCommand}
+"""
+    }
+}
+

--- a/src/com/puppet/jenkinsSharedLibraries/BundleInstall.groovy
+++ b/src/com/puppet/jenkinsSharedLibraries/BundleInstall.groovy
@@ -1,0 +1,22 @@
+package com.puppet.jenkinsSharedLibraries
+
+class BundleInstall extends RvmEnvironment {
+    String bundleInstall
+    BundleInstall(String rubyVersion) {
+        super(rubyVersion)
+        this.bundleInstall = this.rvmCommand + """
+export BUNDLE_BIN=.bundle/bin
+export BUNDLE_PATH=.bundle/gems
+bundle install
+"""
+    }
+
+    BundleInstall(String rubyVersion, String gemfile) {
+        super(rubyVersion)
+        this.bundleInstall = this.rvmCommand + """
+export BUNDLE_BIN=.bundle/bin
+export BUNDLE_PATH=.bundle/gems
+bundle install --gemfile ${gemfile}
+"""
+    }
+}

--- a/src/com/puppet/jenkinsSharedLibraries/ChangeDirectory.groovy
+++ b/src/com/puppet/jenkinsSharedLibraries/ChangeDirectory.groovy
@@ -1,0 +1,10 @@
+package com.puppet.jenkinsSharedLibraries
+
+class ChangeDirectory {
+   def steps
+   ChangeDirectory(steps) { this.steps = steps }
+
+   def chDir(dir){
+      steps.sh "cd ${dir}"
+   }
+}

--- a/src/com/puppet/jenkinsSharedLibraries/RvmEnvironment.groovy
+++ b/src/com/puppet/jenkinsSharedLibraries/RvmEnvironment.groovy
@@ -1,0 +1,14 @@
+package com.puppet.jenkinsSharedLibraries
+
+class RvmEnvironment implements Serializable {
+    String rubyVersion, rvmCommand
+    RvmEnvironment(String rubyVersion) {
+        this.rubyVersion = rubyVersion
+        this.rvmCommand = """#!/bin/bash
+set +x
+source /usr/local/rvm/scripts/rvm
+rvm use ${rubyVersion}
+set -x
+"""
+    }
+}

--- a/vars/run_installer_shim_acceptance.groovy
+++ b/vars/run_installer_shim_acceptance.groovy
@@ -1,0 +1,25 @@
+import com.puppet.jenkinsSharedLibraries.BeakerHostgenerator
+import com.puppet.jenkinsSharedLibraries.Beaker
+import com.puppet.jenkinsSharedLibraries.BundleInstall
+import com.puppet.jenkinsSharedLibraries.BundleExec
+
+def call(String rubyVersion, String platform) {
+    def setup_gems = new BundleInstall(rubyVersion)
+    def bundle_exec = new BundleExec(rubyVersion, 'rake gettext:build_mo[ja]')
+
+    sh "${setup_gems.bundleInstall}"
+    sh "${bundle_exec.bundleExec}"
+
+    def acceptance_gems = new BundleInstall(rubyVersion)
+    def generate_beaker_hosts = new BeakerHostgenerator(rubyVersion, 'http://enterprise.delivery.puppetlabs.net/2019.2/ci-ready', '2019.2.0-rc6-118-ga65d4b8', platform, 'vmpooler', 'hosts.cfg')
+    def run_beaker = new Beaker(rubyVersion, '--xml --debug --root-keys --repo-proxy --hosts hosts.cfg --type pe --keyfile /var/lib/jenkins/.ssh/id_rsa-acceptance --tests tests --preserve-hosts never --pre-suite pre-suite')
+
+    sh """#!/bin/bash
+cd acceptance/ && ${acceptance_gems.bundleInstall}"""
+    sh """#!/bin/bash
+cd acceptance/ && ${generate_beaker_hosts.hostgeneratorScript}
+"""
+    sh """#!/bin/bash
+cd acceptance/ && ${run_beaker.beakerScript}
+"""
+}


### PR DESCRIPTION
This commit adds various library functions and helpers to facilitate
acceptance testing for pe-installer-shim. There are probably a number of
improvements that can be made, and there are currently some hacky pieces
of this to work around an interesting lack of auth/persistence that
occurs on some of our Jenkins hosts