### PR TITLE
(maint) Stop hardcoding PE version for installer-shim

### DIFF
--- a/vars/run_installer_shim_acceptance.groovy
+++ b/vars/run_installer_shim_acceptance.groovy
@@ -3,15 +3,20 @@ import com.puppet.jenkinsSharedLibraries.Beaker
 import com.puppet.jenkinsSharedLibraries.BundleInstall
 import com.puppet.jenkinsSharedLibraries.BundleExec
 
-def call(String rubyVersion, String platform) {
+def call(String rubyVersion, String platform, String peFamily) {
     def setup_gems = new BundleInstall(rubyVersion)
     def bundle_exec = new BundleExec(rubyVersion, 'rake gettext:build_mo[ja]')
+
+    def pe_version = sh (
+            script: "redis-cli -h redis.delivery.puppetlabs.net get ${peFamily}_pe_version",
+            returnStdout: true
+    ).trim()
 
     sh "${setup_gems.bundleInstall}"
     sh "${bundle_exec.bundleExec}"
 
     def acceptance_gems = new BundleInstall(rubyVersion)
-    def generate_beaker_hosts = new BeakerHostgenerator(rubyVersion, 'http://enterprise.delivery.puppetlabs.net/2019.2/ci-ready', '2019.2.0-rc6-118-ga65d4b8', platform, 'vmpooler', 'hosts.cfg')
+    def generate_beaker_hosts = new BeakerHostgenerator(rubyVersion, 'http://enterprise.delivery.puppetlabs.net/2019.2/ci-ready', pe_version, platform, 'vmpooler', 'hosts.cfg')
     def run_beaker = new Beaker(rubyVersion, '--xml --debug --root-keys --repo-proxy --hosts hosts.cfg --type pe --keyfile /var/lib/jenkins/.ssh/id_rsa-acceptance --tests tests --preserve-hosts never --pre-suite pre-suite')
 
     sh """#!/bin/bash


### PR DESCRIPTION
This commit updates the installer-shim acceptance testing script to
accept a PE family parameter and generate the most recent rc- build for
that PE family via redis rather than having a hard-coded PE build that
will quickly become obsolete