### PR TITLE
(maint) Update installer-shim to use Artifactory

### DIFF
--- a/vars/run_installer_shim_acceptance.groovy
+++ b/vars/run_installer_shim_acceptance.groovy
@@ -16,7 +16,7 @@ def call(String rubyVersion, String platform, String peFamily) {
     sh "${bundle_exec.bundleExec}"
 
     def acceptance_gems = new BundleInstall(rubyVersion)
-    def generate_beaker_hosts = new BeakerHostgenerator(rubyVersion, "http://enterprise.delivery.puppetlabs.net/${peFamily}/ci-ready", pe_version, platform, 'vmpooler', 'hosts.cfg')
+    def generate_beaker_hosts = new BeakerHostgenerator(rubyVersion, "https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/${peFamily}/ci-ready", pe_version, platform, 'vmpooler', 'hosts.cfg')
     def run_beaker = new Beaker(rubyVersion, '--xml --debug --root-keys --repo-proxy --hosts hosts.cfg --type pe --keyfile /var/lib/jenkins/.ssh/id_rsa-acceptance --tests tests --preserve-hosts never --pre-suite pre-suite')
 
     sh """#!/bin/bash


### PR DESCRIPTION
This commit updates the pe-installer-shim's acceptance testing script in
this repo to use Artifactory as the default PE build location, as part
of the work for migrating from Saturn to Artifactory