### PR TITLE
(maint) Fix up a syntax error with groovy and the =~ operator

### DIFF
--- a/vars/cut_release_branch.groovy
+++ b/vars/cut_release_branch.groovy
@@ -1,6 +1,6 @@
 def call(String version) {
 
-  if (version =~ '^20[0-9]{2}[.](\d*)[.](\d*)$') {
+  if (version =~ '^20[0-9]{2}[.]([0-9]*)[.]([0-9]*)$') {
     println "${version} is a valid version"
   } else {
     println "${version} is an invalid version"


### PR DESCRIPTION
The =~ operator hates \d, so just using [0-9] as a one for one replacemnet.
Tested the inital of statement with a syntax checker and it passed.