### PR TITLE
(PE-28152) add github processes to cjc editing scripts

### DIFF
--- a/vars/bash/init_release_job_creation.sh
+++ b/vars/bash/init_release_job_creation.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 PE_VERSION=$1
+REPO='ci-job-configs'
+JOB_NAME='init_release_job_creation'
+TEMP_BRANCH="auto/${JOB_NAME}/${PE_VERSION}-release"
+rm -rf ./${REPO}
+git clone git@github.com:puppetlabs/${REPO} ./${REPO}
+cd ${REPO}
+git checkout -b $TEMP_BRANCH
 
 sed -i "/init release anchor point/a \
 \        - pm_conditional-step:\n\
@@ -8,4 +15,9 @@ sed -i "/init release anchor point/a \
 \            m_value_stream: '{value_stream}'\n\
 \            m_projects: '{value_stream}_pe-acceptance-tests_packaging_promotion_${PE_VERSION}-release,{value_stream}_{name}_init-cinext_smoke-upgrade_${PE_VERSION}-release,{value_stream}_{name}_init-cinext_split-smoke-upgrade_${PE_VERSION}-release,{value_stream}_jar-jar_component-update_${PE_VERSION}-release'" resources/job-templates/init.yaml
 
-##TO DO create a PR and push it
+## create a PR and push it
+git add ./resources/job-templates/init.yaml
+git commit -m "${JOB_NAME} for ${PE_VERSION}-release"
+git push origin $TEMP_BRANCH
+PULL_REQUEST="$(git show -s --pretty='format:%s%n%n%b' | hub pull-request -b master -F -)"
+echo "Opened mergeup PR for $(pwd): ${PULL_REQUEST}"

--- a/vars/bash/installer_vanagon_release_job_creation.sh
+++ b/vars/bash/installer_vanagon_release_job_creation.sh
@@ -1,8 +1,17 @@
 #!/bin/sh
 PE_VERSION=$1
+REPO='ci-job-configs'
 FAMILY=`echo $PE_VERSION | sed "s/\(.*\..*\)\..*/\1/"`
 X_FAMILY=`echo $FAMILY | sed "s/\(.*\)\..*/\1/"`
 Y_FAMILY=`echo $FAMILY | sed "s/.*\.\(.*\)/\1/"`
+JOB_NAME='installer_vanagon_release_job_creation'
+YAML_FILEPATH=./jenkii/enterprise/projects/pe-installer-vanagon.yaml
+TEMP_BRANCH="auto/${JOB_NAME}/${PE_VERSION}-release"
+
+rm -rf ./${REPO}
+git clone git@github.com:puppetlabs/${REPO} ./${REPO}
+cd ${REPO}
+git checkout -b $TEMP_BRANCH
 
 # supported_upgrade_defaults logic
 # incase we are basing the release branch off of master
@@ -18,6 +27,11 @@ echo "
             component_scm_branch: '${PE_VERSION}-release'
             vanagon_scm_branch: '${PE_VERSION}-release'
             promote_branch: '${PE_VERSION}-release'
-            <<: *p_${FAMILY_SETTING}_installer_vanagon_settings" >> ./jenkii/enterprise/projects/pe-installer-vanagon.yaml
+            <<: *p_${FAMILY_SETTING}_installer_vanagon_settings" >> $YAML_FILEPATH
 
-##TO DO create a PR and push it
+## create a PR and push it
+git add $YAML_FILEPATH
+git commit -m "${JOB_NAME} for ${PE_VERSION}-release"
+git push origin $TEMP_BRANCH
+PULL_REQUEST="$(git show -s --pretty='format:%s%n%n%b' | hub pull-request -b master -F -)"
+echo "Opened mergeup PR for $(pwd): ${PULL_REQUEST}"

--- a/vars/bash/integration_release_job_creation.sh
+++ b/vars/bash/integration_release_job_creation.sh
@@ -1,21 +1,31 @@
 #!/bin/sh
 PE_VERSION=$1
 CODENAME=$2
+REPO='ci-job-configs'
 FAMILY=`echo $PE_VERSION | sed "s/\(.*\..*\)\..*/\1/"`
 X_FAMILY=`echo $FAMILY | sed "s/\(.*\)\..*/\1/"`
 Y_FAMILY=`echo $FAMILY | sed "s/.*\.\(.*\)/\1/"`
+JOB_NAME='integration_release_job_creation'
+YAML_FILEPATH=./jenkii/enterprise/projects/pe-integration.yaml
+TEMP_BRANCH="auto/${JOB_NAME}/${PE_VERSION}-release"
+
+rm -rf ./${REPO}
+git clone git@github.com:puppetlabs/${REPO} ./${REPO}
+cd ${REPO}
+git pull
+git checkout -b $TEMP_BRANCH
 
 # supported_upgrade_defaults logic
 # incase we are basing the release branch off of master
 upgrade_default_name="p_${X_FAMILY}_${Y_FAMILY}_supported_upgrade_defaults"
-grep_output=`grep ${upgrade_default_name} jenkii/enterprise/projects/pe-integration.yaml`
+grep_output=`grep ${upgrade_default_name} $YAML_FILEPATH`
 FAMILY_SETTING="${X_FAMILY}_${Y_FAMILY}"
 if [ -z "$grep_output" ]; then
     FAMILY_SETTING="master"
 fi
 
 # Renames the usual p_scm_alt_code_name, which is used by pe-backup-tools, in order to avoid duplicate job declerations
-`sed -i "s/p_scm_alt_code_name: '${CODENAME}'/p_scm_alt_code_name: '${CODENAME}_replacement'/" ./jenkii/enterprise/projects/pe-integration.yaml`
+`sed -i "s/p_scm_alt_code_name: '${CODENAME}'/p_scm_alt_code_name: '${CODENAME}_replacement'/" $YAML_FILEPATH`
 
 echo "
         - '{value_stream}_{name}_workspace-creation_{qualifier}':
@@ -42,7 +52,12 @@ echo "
             pe_family: ${FAMILY}
             scm_branch: ${PE_VERSION}-release
             p_scm_alt_code_name: '${CODENAME}'
-            <<: *p_${FAMILY_SETTING}_settings" >> ./jenkii/enterprise/projects/pe-integration.yaml
+            <<: *p_${FAMILY_SETTING}_settings" >> $YAML_FILEPATH
 
 
-##TO DO create a PR and push it
+## create a PR and push it
+git add $YAML_FILEPATH
+git commit -m "${JOB_NAME} for ${PE_VERSION}-release"
+git push origin $TEMP_BRANCH
+PULL_REQUEST="$(git show -s --pretty='format:%s%n%n%b' | hub pull-request -b master -F -)"
+echo "Opened mergeup PR for $(pwd): ${PULL_REQUEST}"

--- a/vars/bash/jar_jar_release_job_creation.sh
+++ b/vars/bash/jar_jar_release_job_creation.sh
@@ -1,8 +1,18 @@
 #!/bin/sh
 PE_VERSION=$1
+REPO='ci-job-configs'
 FAMILY=`echo $PE_VERSION | sed "s/\(.*\..*\)\..*/\1/"`
 X_FAMILY=`echo $FAMILY | sed "s/\(.*\)\..*/\1/"`
 Y_FAMILY=`echo $FAMILY | sed "s/.*\.\(.*\)/\1/"`
+JOB_NAME='jar_jar_release_job_creation'
+YAML_FILEPATH=./jenkii/enterprise/projects/jar-jar.yaml
+TEMP_BRANCH="auto/${JOB_NAME}/${PE_VERSION}-release"
+
+rm -rf ./${REPO}
+git clone git@github.com:puppetlabs/${REPO} ./${REPO}
+cd ${REPO}
+git pull
+git checkout -b $TEMP_BRANCH
 
 echo "
         # ---- ${PE_VERSION}-release ----
@@ -18,7 +28,12 @@ echo "
 
         - '{value_stream}_{name}_release-clj_{qualifier}':
             slnotifier_notify_success: True
-            scm_branch: '${PE_VERSION}-release'" >> ./jenkii/enterprise/projects/jar-jar.yaml
+            scm_branch: '${PE_VERSION}-release'" >> $YAML_FILEPATH
 
 
-##TO DO create a PR and push it
+## create a PR and push it
+git add $YAML_FILEPATH
+git commit -m "${JOB_NAME} for ${PE_VERSION}-release"
+git push origin $TEMP_BRANCH
+PULL_REQUEST="$(git show -s --pretty='format:%s%n%n%b' | hub pull-request -b master -F -)"
+echo "Opened mergeup PR for $(pwd): ${PULL_REQUEST}"

--- a/vars/bash/modules_vanagon_release_job_creation.sh
+++ b/vars/bash/modules_vanagon_release_job_creation.sh
@@ -1,13 +1,23 @@
 #!/bin/sh
 PE_VERSION=$1
+REPO='ci-job-configs'
 FAMILY=`echo $PE_VERSION | sed "s/\(.*\..*\)\..*/\1/"`
 X_FAMILY=`echo $FAMILY | sed "s/\(.*\)\..*/\1/"`
 Y_FAMILY=`echo $FAMILY | sed "s/.*\.\(.*\)/\1/"`
+JOB_NAME='modules_vanagon_release_job_creation'
+YAML_FILEPATH=./jenkii/enterprise/projects/pe-modules-vanagon.yaml
+TEMP_BRANCH="auto/${JOB_NAME}/${PE_VERSION}-release"
+
+rm -rf ./${REPO}
+git clone git@github.com:puppetlabs/${REPO} ./${REPO}
+cd ${REPO}
+git pull
+git checkout -b $TEMP_BRANCH
 
 # supported_upgrade_defaults logic
 # incase we are basing the release branch off of master
 upgrade_default_name="p_${X_FAMILY}_${Y_FAMILY}_installer_vanagon_settings"
-grep_output=`grep ${upgrade_default_name} jenkii/enterprise/projects/pe-modules-vanagon.yaml`
+grep_output=`grep ${upgrade_default_name} $YAML_FILEPATH`
 FAMILY_SETTING="${X_FAMILY}_${Y_FAMILY}"
 if [ -z "$grep_output" ]; then
     FAMILY_SETTING="master"
@@ -20,6 +30,11 @@ echo "
             component_scm_branch: '${PE_VERSION}-release'
             promote_branch: '${PE_VERSION}-release'
             promote_into: '${PE_VERSION}-release'
-            <<: *p_${FAMILY_SETTING}_pe_modules_vanagon" >> ./jenkii/enterprise/projects/pe-modules-vanagon.yaml
+            <<: *p_${FAMILY_SETTING}_pe_modules_vanagon" >> $YAML_FILEPATH
 
-##TO DO create a PR and push it
+## create a PR and push it
+git add $YAML_FILEPATH
+git commit -m "${JOB_NAME} for ${PE_VERSION}-release"
+git push origin $TEMP_BRANCH
+PULL_REQUEST="$(git show -s --pretty='format:%s%n%n%b' | hub pull-request -b master -F -)"
+echo "Opened mergeup PR for $(pwd): ${PULL_REQUEST}"


### PR DESCRIPTION
This pr updates our cjc job scripts to  push up the branch and open a PR to master, along with some naming convention and workflow changes