### PR TITLE
(maint) Add worker label to called node blocks

### DIFF
--- a/vars/cut_release_branch.groovy
+++ b/vars/cut_release_branch.groovy
@@ -7,7 +7,7 @@ def call(String version, String branch_from) {
     throw new Exception("Invalid version")
   }
   //Execute bash script, catch and print output and errors
-  node {
+  node('worker') {
     sh "curl -O https://raw.githubusercontent.com/puppetlabs/puppet_jenkins_shared_libraries/master/vars/bash/cut_release_branch.sh"
     sh "chmod +x cut_release_branch.sh"
     sh "./cut_release_branch.sh $version $branch_from"

--- a/vars/init_release_job_creation.groovy
+++ b/vars/init_release_job_creation.groovy
@@ -7,7 +7,7 @@ def call(String version) {
     throw new Exception("Invalid version")
   }
   //Execute bash script, catch and print output and errors
-  node {
+  node('worker') {
     sh "curl -O https://raw.githubusercontent.com/puppetlabs/puppet_jenkins_shared_libraries/master/vars/bash/init_release_job_creation.sh"
     sh "chmod +x init_release_job_creation.sh"
     sh "./init_release_job_creation.sh $version"

--- a/vars/installer_vanagon_release_job_creation.groovy
+++ b/vars/installer_vanagon_release_job_creation.groovy
@@ -7,7 +7,7 @@ def call(String version) {
     throw new Exception("Invalid version")
   }
   //Execute bash script, catch and print output and errors
-  node {
+  node('worker') {
     sh "curl -O https://raw.githubusercontent.com/puppetlabs/puppet_jenkins_shared_libraries/master/vars/bash/installer_vanagon_release_job_creation.sh"
     sh "chmod +x installer_vanagon_release_job_creation.sh"
     sh "./installer_vanagon_release_job_creation.sh $version"

--- a/vars/integration_release_job_creation.groovy
+++ b/vars/integration_release_job_creation.groovy
@@ -7,7 +7,7 @@ def call(String version, String codename) {
     throw new Exception("Invalid version")
   }
   //Execute bash script, catch and print output and errors
-  node {
+  node('worker') {
     sh "curl -O https://raw.githubusercontent.com/puppetlabs/puppet_jenkins_shared_libraries/master/vars/bash/integration_release_job_creation.sh"
     sh "chmod +x integration_release_job_creation.sh"
     sh "./integration_release_job_creation.sh $version $codename"

--- a/vars/jar_jar_release_job_creation.groovy
+++ b/vars/jar_jar_release_job_creation.groovy
@@ -7,7 +7,7 @@ def call(String version) {
     throw new Exception("Invalid version")
   }
   //Execute bash script, catch and print output and errors
-  node {
+  node('worker') {
     sh "curl -O https://raw.githubusercontent.com/puppetlabs/puppet_jenkins_shared_libraries/master/vars/bash/jar_jar_release_job_creation.sh"
     sh "chmod +x jar_jar_release_job_creation.sh"
     sh "./jar_jar_release_job_creation.sh $version"

--- a/vars/modules_vanagon_release_job_creation.groovy
+++ b/vars/modules_vanagon_release_job_creation.groovy
@@ -7,7 +7,7 @@ def call(String version) {
     throw new Exception("Invalid version")
   }
   //Execute bash script, catch and print output and errors
-  node {
+  node('worker') {
     sh "curl -O https://raw.githubusercontent.com/puppetlabs/puppet_jenkins_shared_libraries/master/vars/bash/modules_vanagon_release_job_creation.sh"
     sh "chmod +x modules_vanagon_release_job_creation.sh"
     sh "./modules_vanagon_release_job_creation.sh $version"

--- a/vars/tag_for_release.groovy
+++ b/vars/tag_for_release.groovy
@@ -8,7 +8,7 @@ def call(String version) {
   }
 
   //Execute bash script, catch and print output and errors
-  node {
+  node('worker') {
     sh "curl -O https://raw.githubusercontent.com/puppetlabs/puppet_jenkins_shared_libraries/master/vars/bash/tag_for_release.sh"
     sh "chmod +x tag_for_release.sh"
     sh "./tag_for_release.sh $version"


### PR DESCRIPTION
Our scripts were running on the jenkins master, not the worker agent. This not only does not have the required binaries, like hub, but it is also potentially hazardous. This pr adds the worker label to all activated nodes.