### PR TITLE
(maint) Update the integration non-stanard agent job

### DIFF
--- a/vars/bash/integration_release_job_creation.sh
+++ b/vars/bash/integration_release_job_creation.sh
@@ -42,7 +42,7 @@ echo "
               - centos6-64mcd-64agent%2Cpe_postgres.
             <<: *p_${FAMILY_SETTING}_supported_upgrade_defaults
 
-        - 'pe-integration-non-standard-agents':
+        - 'pe-integration-non-standard-agents-release':
             pe_family: ${FAMILY}
             scm_branch: ${PE_VERSION}-release
             pipeline_scm_branch: ${PE_VERSION}-release


### PR DESCRIPTION
The non-standard job needs to use the -release job group in order to
get the correct PE build number from redis.