### PR TITLE
(maint) Update release branch script to use codename

### DIFF
--- a/vars/bash/cut_release_branch.sh
+++ b/vars/bash/cut_release_branch.sh
@@ -1,7 +1,7 @@
-#USAGE: ./cut_release_branch.sh <version> <branch_from>
+#USAGE: ./cut_release_branch.sh <version> <codename>
 
 version=$1
-branch_from=$2
+codename=$2
 
 rm -rf ./${GITHUB_PROJECT}
 git clone git@github.com:puppetlabs/${GITHUB_PROJECT} ./${GITHUB_PROJECT}
@@ -15,24 +15,18 @@ then
   exit 1
 fi
 
-if [ -z "$branch_from" ]
+git checkout ${codename}
+if [[ ("$?" == 0) ]]
 then
-  FAMILY=`echo ${version} | sed "s/\(.*\..*\)\..*/\1/"`
-  BRANCH_FOUND=`git branch --list $FAMILY.x`
-
-  # is the X.Y.Z branch isn't created then we're basing inital checkout off of master
-  if [ -z "$BRANCH_FOUND" ]
-  then
-    git checkout master
-  else
-    git checkout ${FAMILY}.x
-  fi
+  git checkout -b ${version}-release
+  git push origin ${version}-release
 else
-  git checkout ${branch_from}
-fi
+  FAMILY=`echo ${version} | sed "s/\(.*\..*\)\..*/\1/"`
 
-git checkout -b ${version}-release
-git push origin ${version}-release
+  git checkout ${FAMILY}.x
+  git checkout -b ${version}-release
+  git push origin ${version}-release
+fi
 
 cd ..
 rm -rf ${GITHUB_PROJECT}

--- a/vars/cut_release_branch.groovy
+++ b/vars/cut_release_branch.groovy
@@ -1,4 +1,4 @@
-def call(String version, String branch_from) {
+def call(String version, String codename) {
 
   if (version =~ '^20[0-9]{2}[.]([0-9]*)[.]([0-9]*)$') {
     println "${version} is a valid version"
@@ -10,6 +10,6 @@ def call(String version, String branch_from) {
   node('worker') {
     sh "curl -O https://raw.githubusercontent.com/puppetlabs/puppet_jenkins_shared_libraries/master/vars/bash/cut_release_branch.sh"
     sh "chmod +x cut_release_branch.sh"
-    sh "bash cut_release_branch.sh $version $branch_from"
+    sh "bash cut_release_branch.sh $version $codename"
   }
 }


### PR DESCRIPTION
Instead of using a `branch_from` parameter, this commit updates the
script to instead use a codename. This will hopefully account for the
difference in using versions or codenames as branch names across our
different repos.

The way this will work is that the script will try to check out a branch
by first using the codename, and then will use the version parsing logic
to check out a version branch if the codename checkout fails. This is
not the most elegant solution ever, but should work