### PR TITLE
Enable kickoff for release branch

### DIFF
--- a/vars/bash/integration_release_job_creation.sh
+++ b/vars/bash/integration_release_job_creation.sh
@@ -46,11 +46,13 @@ echo "
             pe_family: ${FAMILY}
             scm_branch: ${PE_VERSION}-release
             pipeline_scm_branch: ${PE_VERSION}-release
+            kickoff_disabled: False
             <<: *p_${FAMILY_SETTING}_non_standard_settings
 
         - 'pe-integration-full-release':
             pe_family: ${FAMILY}
             scm_branch: ${PE_VERSION}-release
+            kickoff_disabled: False
             p_scm_alt_code_name: '${CODENAME}'
             <<: *p_${FAMILY_SETTING}_settings" >> $YAML_FILEPATH
 


### PR DESCRIPTION
The 'kickoff_disabled' property for release branch is inherited from
main settings and if we disable kickoff there for mainline pipeline
release pipeline also won't be kicked off. So explicitly enable kickoff
for release pipeline