### PR TITLE
(RE-13292) Add script for tagging enterprise-dist rc tags

### DIFF
--- a/vars/bash/tag_enterprise_dist_next_rc.sh
+++ b/vars/bash/tag_enterprise_dist_next_rc.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash --login -e
+
+#USAGE: ./tag_enterprise_dist_next_rc.sh <version> <branch_from>
+set +x
+source /usr/local/rvm/scripts/rvm
+rvm use 2.5.1
+set -x
+
+version=${1:-invalid}
+branch_from=${2:-invalid}
+
+# make sure our params are set to something reasonable
+if [[ $version == invalid ]]; then
+  echo "Error...looks like param VERSION was set incorrectly, it must be set to a PE version in x.y.z format"
+  exit 1
+fi
+
+if [[ $branch_from == invalid ]]; then
+  echo "Error...looks like param BRANCH_FROM was set incorrectly, it must be set to a valid PE branch"
+  exit 1
+fi
+
+export BUNDLE_BIN=.bundle/bin
+export BUNDLE_PATH=.bundle/gems
+export PATH=/opt/puppetlabs/puppet/bin:$PATH
+
+rm -rf ./$GITHUB_PROJECT
+git clone git@github.com:puppetlabs/$GITHUB_PROJECT ./$GITHUB_PROJECT
+
+cd $GITHUB_PROJECT
+
+bundle install --path $BUNDLE_PATH --retry 3
+
+: === Checking out release branch $version-release
+git checkout $version-release
+
+: === Pushing empty commit to $version-release and tagging next rc
+bundle exec rake new_release:push_empty_commit PE_BRANCH_NAME=$version-release
+bundle exec rake new_release:create_and_push_rc_tag PE_BRANCH_NAME=$version-release
+
+
+: === Checking out mainline branch $branch_from
+git checkout $branch_from
+: === Pushing empty commit to $branch_from
+bundle exec rake new_release:push_empty_commit PE_BRANCH_NAME=$branch_from
+
+# If branch_from is master we tag next release with next Y (2019.4.0 -> 2019.5.0)
+# Otherwise we're branching from an LTS branch so tag next Z (2018.1.11 -> 2018.1.12)
+: === Tagging next rc tag on $branch_from
+if [[ $branch_from == "master" ]] ; then
+    bundle exec rake new_release:create_and_push_new_y_tag PE_BRANCH_NAME=$branch_from
+else
+    bundle exec rake new_release:create_and_push_new_z_tag PE_BRANCH_NAME=$branch_from
+fi

--- a/vars/tag_enterprise_dist_next_rc.groovy
+++ b/vars/tag_enterprise_dist_next_rc.groovy
@@ -1,0 +1,21 @@
+import com.puppet.jenkinsSharedLibraries.BundleInstall
+
+def call(String version, String codename) {
+
+  rubyVersion = "2.5.1"
+  def setup_gems = new BundleInstall(rubyVersion)
+
+  sh "${setup_gems.bundleInstall}"
+
+  if (version =~ '^20[0-9]{2}[.]([0-9]*)[.]([0-9]*)$') {
+    println "${version} is a valid version"
+  } else {
+    println "${version} is an invalid version"
+    throw new Exception("Invalid version")
+  }
+  //Execute bash script, catch and print output and errors
+  node('worker') {
+    sh "curl -O https://raw.githubusercontent.com/puppetlabs/puppet_jenkins_shared_libraries/master/vars/bash/tag_enterprise_dist_next_rc.sh"
+    sh "bash tag_enterprise_dist_next_rc.sh $version $codename"
+  }
+}


### PR DESCRIPTION
This is used when we are setting up release branches to differentiate the streams

nitpicks on making the bash script prettier/better are welcome! 

job: https://cinext-jenkinsmaster-pipeline-prod-1.delivery.puppetlabs.net/job/enterprise-dist_release_branch_creation/

```
+ : === Checking out release branch 9999.9.9-release
+ git checkout 9999.9.9-release
Switched to a new branch '9999.9.9-release'
Branch 9999.9.9-release set up to track remote branch 9999.9.9-release from origin.
+ : === Pushing empty commit to 9999.9.9-release and tagging next rc
+ bundle exec rake new_release:push_empty_commit PE_BRANCH_NAME=9999.9.9-release
Creating and pushing empty commit to 9999.9.9-release
+ bundle exec rake new_release:create_and_push_rc_tag PE_BRANCH_NAME=9999.9.9-release
From github.com:puppetlabs/enterprise-dist
 * branch                9999.9.9-release -> FETCH_HEAD
Tagging with '9999.9.9-rc19'
+ : === Checking out mainline branch 9999.9.x
+ git checkout 9999.9.x
Switched to a new branch '9999.9.x'
Branch 9999.9.x set up to track remote branch 9999.9.x from origin.
+ : === Pushing empty commit to 9999.9.x
+ bundle exec rake new_release:push_empty_commit PE_BRANCH_NAME=9999.9.x
Creating and pushing empty commit to 9999.9.x
+ : === Tagging next rc tag on 9999.9.x
+ [[ 9999.9.x == \m\a\s\t\e\r ]]
+ bundle exec rake new_release:create_and_push_new_z_tag PE_BRANCH_NAME=9999.9.x
From github.com:puppetlabs/enterprise-dist
 * branch                9999.9.x   -> FETCH_HEAD
Tagging with '9999.9.10-rc0'
```

I commented out the actual parts that tag and push things (which have been used and tested before) and made sure the information being passed was correct.
This pairs with these changes: https://github.com/puppetlabs/enterprise-dist/pull/3666/files that i'll get a PR up for soon (https://github.com/puppetlabs/enterprise-dist/pull/3668)