### PR TITLE
Add Ruby Helper Vars

### DIFF
--- a/vars/bundleExec.groovy
+++ b/vars/bundleExec.groovy
@@ -1,0 +1,7 @@
+import com.puppet.jenkinsSharedLibraries.BundleExec
+
+def call(String rubyVersion, String bundleExecCommand) {
+  def bundle = new BundleExec(rubyVersion, bundleExecCommand)
+
+  sh "${bundle.bundleExec}"
+}

--- a/vars/bundleInstall.groovy
+++ b/vars/bundleInstall.groovy
@@ -1,0 +1,13 @@
+import com.puppet.jenkinsSharedLibraries.BundleInstall
+
+def call(String rubyVersion) {
+  def bundle = new BundleInstall(rubyVersion)
+
+  sh "${bundle.bundleInstall}"
+}
+
+def call (String rubyVersion, String gemfile) {
+  def bundle = new BundleInstall(rubyVersion, gemfile)
+
+  sh "${bundle.bundleInstall}"
+}


### PR DESCRIPTION
Some testing pipelines will only need very basic ruby commands like
`bundle install..` and `bundle exec rake...`. By adding these basic
helpers we can avoid polluting the `vars` directory with every teams
bespoke pipeline calling commands, and we can avoid having to use the
`script` stage task in declaritive pipelines.

If we don't add these helpers then there is no easy way to access the
classes defined in files like `BundleInstall.groovy` from declaritive
pipelines without having to use a `script` step in Jenkinsfiles.