### PR TITLE
(PE-30014) Fix up installer_team_release_creation_job 

### DIFF
--- a/vars/bash/installer_team_release_creation_job.sh
+++ b/vars/bash/installer_team_release_creation_job.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 readonly PE_VERSION=$1
 readonly CODENAME=$2
+readonly KICKOFF_HOUR=$3
 readonly FAMILY=`echo $PE_VERSION | sed "s/\(.*\..*\)\..*/\1/"`
 readonly X_FAMILY=`echo $FAMILY | sed "s/\(.*\)\..*/\1/"`
 readonly Y_FAMILY=`echo $FAMILY | sed "s/.*\.\(.*\)/\1/"`
@@ -14,13 +15,13 @@ readonly TEMP_BRANCH="auto/${JOB_NAME}/${PE_VERSION}-release"
 init_release_job_creation() {
   echo 'Updating init.yaml...'
   sed -i "/init release anchor point/a \
+\        # ---- ${PE_VERSION}-release ----
 \        - pm_conditional-step:\n\
 \            m_scm_branch: '${PE_VERSION}-release'\n\
 \            m_name: '{name}'\n\
 \            m_value_stream: '{value_stream}'\n\
 \            m_projects: '{value_stream}_pe-acceptance-tests_packaging_promotion_${PE_VERSION}-release,{value_stream}_{name}_init-cinext_smoke-upgrade_${PE_VERSION}-release,{value_stream}_{name}_init-cinext_split-smoke-upgrade_${PE_VERSION}-release,{value_stream}_jar-jar_component-update_${PE_VERSION}-release'" resources/job-templates/init.yaml
   git add ./resources/job-templates/init.yaml
-  git commit -m "${FUNCNAME[0]} for ${PE_VERSION}-release"
 }
 
 ##Modify jar-jar.yaml file for updating PE compose job
@@ -45,51 +46,56 @@ jar_jar_release_job_creation() {
 
 
   git add $yaml_filepath
-  git commit -m "${FUNCNAME[0]} for ${PE_VERSION}-release"
 }
 
 ##Create integration pe_acceptance_tests release pipeline
 integration_release_job_creation() {
   local yaml_filepath=./jenkii/enterprise/projects/pe-integration.yaml
-  local settings_default="p_${PE_FAMILY}_supported_upgrade_defaults"
+  local settings_default="p_${PE_FAMILY}_settings"
   local settings_default_exists=$(grep ${settings_default} $yaml_filepath)
   local family_setting=$PE_FAMILY
   if [ -z "$settings_default_exists" ]; then
-      family_setting="master"
+      family_setting="${CODENAME}"
   fi
 
   echo 'Updating pe-integration.yaml...'
-  # Renames the usual p_scm_alt_code_name, which is used by pe-backup-tools, in order to avoid duplicate job declerations
+  # Renames the usual p_scm_alt_code_name, which is used by pe-backup-tools, in order to avoid duplicate job declarations
   (sed -i "s/p_scm_alt_code_name: '${CODENAME}'/p_scm_alt_code_name: '${CODENAME}_replacement'/" $yaml_filepath)
 
   sed -i "/${family_setting} integration release anchor point/a \
+\        # ---- ${PE_VERSION}-release ----
 \        - '{value_stream}_{name}_workspace-creation_{qualifier}':\n\
 \            scm_branch: ${PE_VERSION}-release\n\
 \            qualifier: '{scm_branch}'\n\
 \n\
 \        - 'pe-integration-smoke-upgrade-release':\n\
+\            kickoff_disabled: False\n\
 \            pe_family: ${FAMILY}\n\
 \            scm_branch: ${PE_VERSION}-release\n\
 \            cinext_preserve_resources: 'true'\n\
 \            beaker_helper: 'lib/beaker_helper.rb'\n\
 \            beaker_tag: 'risk:high,risk:medium'\n\
-\            <<: *p_${family_setting}_supported_upgrade_defaults\n\
+\            <<: *p_upgrade_axes_${family_setting}\n\
 \n\
 \        - 'pe-integration-non-standard-agents-release':\n\
+\            kickoff_disabled: False\n\
+\            timed_trigger_cron: '00 ${KICKOFF_HOUR} * * *'\n\
 \            pe_family: ${FAMILY}\n\
 \            scm_branch: ${PE_VERSION}-release\n\
 \            pipeline_scm_branch: ${PE_VERSION}-release\n\
 \            <<: *p_${family_setting}_non_standard_settings\n\
 \n\
 \        - 'pe-integration-full-release':\n\
+\            kickoff_disabled: False\n\
+\            timed_trigger_cron: '00 ${KICKOFF_HOUR} * * *'\n\
 \            pe_family: ${FAMILY}\n\
 \            scm_branch: ${PE_VERSION}-release\n\
 \            p_scm_alt_code_name: '${CODENAME}'\n\
 \            <<: *p_${family_setting}_settings\n\
+\            <<: *p_upgrade_axes_${family_setting}\n\
 \            p_proxy_genconfig_extra: '--pe_dir=https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/${FAMILY}/release/ci-ready/'" $yaml_filepath
 
   git add $yaml_filepath
-  git commit -m "${FUNCNAME[0]} for ${PE_VERSION}-release"
 }
 
 ##Create pe-installer-vanagon release pipeline
@@ -99,11 +105,12 @@ installer_vanagon_release_job_creation() {
   local settings_default_exists=$(grep ${settings_default} jenkii/enterprise/projects/pe-installer-vanagon.yaml)
   local family_setting=$PE_FAMILY
   if [ -z "$settings_default_exists" ]; then
-      family_setting="master"
+      family_setting="${CODENAME}"
   fi
 
   echo 'Updating pe-installer-vanagon.yaml...'
   echo "
+        # ---- ${PE_VERSION}-release ----
         - 'pe-installer-vanagon-with-pez-and-ui-acceptance':
             component_scm_branch: '${PE_VERSION}-release'
             vanagon_scm_branch: '${PE_VERSION}-release'
@@ -111,7 +118,6 @@ installer_vanagon_release_job_creation() {
             <<: *p_${family_setting}_installer_vanagon_settings" >> $yaml_filepath
 
   git add $yaml_filepath
-  git commit -m "${FUNCNAME[0]} for ${PE_VERSION}-release"
 }
 
 ##Create pe-modules-vanagon release pipeline
@@ -121,11 +127,12 @@ modules_vanagon_release_job_creation() {
   local settings_default_exists=$(grep ${settings_default} $yaml_filepath)
   local family_setting=$PE_FAMILY
   if [ -z "$settings_default_exists" ]; then
-    family_setting="master"
+    family_setting="${CODENAME}"
   fi
 
   echo 'Updating pe-modules-vanagon.yaml...'
   echo "
+        # ---- ${PE_VERSION}-release ----
         - 'pe-modules-vanagon-suite-pipeline-daily':
             qualifier: '${PE_VERSION}-release'
             scm_branch: '${PE_VERSION}-release'
@@ -135,7 +142,6 @@ modules_vanagon_release_job_creation() {
             <<: *p_${family_setting}_pe_modules_vanagon" >> $yaml_filepath
 
   git add $yaml_filepath
-  git commit -m "${FUNCNAME[0]} for ${PE_VERSION}-release"
 }
 
 ##Create pe-installer-shim release pipeline
@@ -144,24 +150,29 @@ pe_installer_shim_job_creation() {
 
   echo 'Updating pe-installer-shim.yaml...'
   echo "
+        # ---- ${PE_VERSION}-release ----
         - 'pe-installer-shim':
             scm_branch: '${PE_VERSION}-release' # pe-installer-shim branch to trigger from
             promote_branch: '${PE_VERSION}-release' # enterprise-dist branch to promote into
+            p_run_pez: False
             qualifier: '${PE_VERSION}-release'" >> $yaml_filepath
 
   git add $yaml_filepath
-  git commit -m "${FUNCNAME[0]} for ${PE_VERSION}-release"
 }
 
 ##Create monorepo promotion release pipeline
-monorepo_release_job_creation() {
-  local yaml_filepath=./jenkii/enterprise/projects/monorepo-promote.yaml
+pe_modules_release_job_creation() {
+  local yaml_filepath=./jenkii/enterprise/projects/pe-modules.yaml
+  local family_setting=$CODENAME
+  # pe_family: main when branch is main, otherwise $FAMILY
+  if [[ $CODENAME =~ \.x ]]; then
+    family_setting=$FAMILY
+  fi
 
-  echo 'Updating monorepo-promote.yaml...'
+  echo 'Updating pe-modules.yaml...'
   echo "
-        - 'monorepo-component-pipeline':
-            unit_ruby_versions:
-              - ruby-2.5.1
+        # ---- ${PE_VERSION}-release ----
+        - 'puppet-enterprise-modules-component-pipeline':
             p_component_branch: '${PE_VERSION}-release'
             qualifier: '${PE_VERSION}-release'
             next_branch: ''
@@ -170,9 +181,112 @@ monorepo_release_job_creation() {
             vanagon_scm_branch: '${PE_VERSION}-release'
             promote_branch: '${PE_VERSION}-release'
             pe_promotion: 'FALSE'" >> $yaml_filepath
+  # These secondary pipelines are just for 2019.8+
+  # I think they're probably only for pe-admin, but not entirely sure,
+  # so we'll keep promoting p-e-m into pe-installer-vanagon anyway.
+  if (($X_FAMILY > 2018)); then
+    echo "
+        - 'puppet-enterprise-modules-secondary-component-pipeline':
+            p_component_branch: '${PE_VERSION}-release'
+            qualifier: '${PE_VERSION}-release_pe-installer'
+            next_branch: ''
+            p_components_to_prep: 'pe-installer-vanagon'
+            p_vanagon_repo: 'pe-installer-vanagon'
+            p_vanagon_project_name: 'pe-installer-vanagon'
+            p_vanagon_repo_branch: '${PE_VERSION}-release'
+            component_scm_branch: '${PE_VERSION}-release'
+            vanagon_scm_branch: '${PE_VERSION}-release'
+            promote_branch: '${PE_VERSION}-release'
+            pe_promotion: 'FALSE'
+        - 'pe-integration-module-pr':
+            cinext_enabled: 'false'
+            scm_branch: '${PE_VERSION}-release'
+            pe_family: ${family_setting}
+            p_split_topology: 'pe-postgres'
+            upgrade_from: '2019.4.0'" >> $yaml_filepath
+  fi
 
   git add $yaml_filepath
-  git commit -m "${FUNCNAME[0]} for ${PE_VERSION}-release"
+}
+
+pe_installer_promote_release_job_creation() {
+  local yaml_filepath=./jenkii/enterprise/projects/pe_installer-promote.yaml
+  echo 'Updating pe_installer-promote.yaml...'
+  echo "
+        # ---- ${PE_VERSION}-release ----
+        - 'ruby-vanagon-component-pipeline':
+            p_rvm_ruby_version: 'ruby-2.5.1'
+            p_component_branch: '${PE_VERSION}-release'
+            component_scm_branch: '${PE_VERSION}-release'
+            qualifier: '${PE_VERSION}-release'
+            next_branch: ''
+            p_vanagon_repo_branch: '${PE_VERSION}-release'
+            vanagon_scm_branch: '${PE_VERSION}-release'
+            pe_promotion: 'TRUE'" >> $yaml_filepath
+
+  git add $yaml_filepath
+}
+
+pe_backup_tools_release_job_creation() {
+  local yaml_filepath=./jenkii/enterprise/projects/pe-backup-tools.yaml
+  local settings_default="p_${PE_FAMILY}_pe_backup_tools_settings"
+  local settings_default_exists=$(grep ${settings_default} $yaml_filepath)
+  local family_setting=$PE_FAMILY # e.g. 2019_8
+  local family_version=$FAMILY # e.g. 2019.8
+  # 'main'
+  if [ -z "$settings_default_exists" ]; then
+    family_setting="${CODENAME}"
+    family_version="${CODENAME}"
+  fi
+
+  echo 'Updating pe-backup-tools.yaml...'
+  sed -i "/pe-backup-tools release anchor point/a \
+\        # ---- ${PE_VERSION}-release ----\n\
+\        - 'pe-etc-vanagon-pipeline':\n\
+\            component_scm_branch: '${PE_VERSION}-release'\n\
+\            vanagon_scm_branch: '${PE_VERSION}-release'\n\
+\            promote_branch: '${PE_VERSION}-release'\n\
+\            p_optional_path: '${family_setting}/'\n\
+\            env_command: |\n\
+\              source /usr/local/rvm/scripts/rvm\n\
+\              rvm use {rvm_ruby_version}\n\
+\              export pe_ver=\\\"\$(redis-cli -h redis.delivery.puppetlabs.net get ${family_version}_release_pe_version)\\\"\n\
+\              export PE_FAMILY=${family_version}\n\
+\              export BUNDLE_PATH=.bundle/gems BUNDLE_BIN=.bundle/bin SHA=\$SUITE_COMMIT CONFIG=config/nodes/\$TEST_TARGET.yaml\n\
+\              eval \"$(ssh-agent -t 24h -s)\"\n\
+\              ssh-add \"\${{HOME}}/.ssh/id_rsa\"\n\
+\              ssh-add \"\${{HOME}}/.ssh/id_rsa-acceptance\"\n\
+\            <<: *p_${family_setting}_pe_backup_tools_settings\n\
+\        - 'pe-ruby-vanagon-pr':\n\
+\            component_scm_branch: '${PE_VERSION}-release'\n\
+\            vanagon_scm_branch: '${PE_VERSION}-release'\n\
+\            env_command: |\n\
+\              source /usr/local/rvm/scripts/rvm\n\
+\              rvm use {rvm_ruby_version}\n\
+\              export pe_ver=\"\$(redis-cli -h redis.delivery.puppetlabs.net get ${family_version}_release_pe_version)\"\n\
+\              export PE_FAMILY=${family_version}\n\
+\              export BUNDLE_PATH=.bundle/gems BUNDLE_BIN=.bundle/bin SHA=\$SUITE_COMMIT CONFIG=config/nodes/\$TEST_TARGET.yaml\n\
+\              eval \"$(ssh-agent -t 24h -s)\"\n\
+\              ssh-add \"\${{HOME}}/.ssh/id_rsa\"\n\
+\              ssh-add \"\${{HOME}}/.ssh/id_rsa-acceptance\"\n\
+\            <<: *p_${family_setting}_pe_backup_tools_settings\n" $yaml_filepath
+
+
+  echo "
+        # ---- ${PE_VERSION}-release ----
+        - 'pe-etc-vanagon-suite-pipeline-daily':
+            scm_branch: '${PE_VERSION}-release'
+            pe_family: '${family_version}' #needed for PEZ
+            promote_into: '${PE_VERSION}-release'
+            p_pkg-int-sys-testing_env-command: |
+              export pe_dist_dir=https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/${family_version}/release/ci-ready
+              export PE_FAMILY=${family_version}
+              eval \"\$(ssh-agent -t 24h -s)\"
+              ssh-add \$HOME/.ssh/id_rsa
+              ssh-add \$HOME/.ssh/id_rsa-acceptance
+            <<: *p_${family_setting}_pe_backup_tools_vanagon_settings" >> $yaml_filepath
+
+  git add $yaml_filepath
 }
 
 error_exit() {
@@ -192,7 +306,11 @@ main() {
   installer_vanagon_release_job_creation || error_exit 'Updating pe-installer-vanagon.yaml failed'
   modules_vanagon_release_job_creation || error_exit 'Updating pe-modules-vanagon.yaml failed'
   pe_installer_shim_job_creation || error_exit 'Updating pe-installer-shim.yaml failed'
-  monorepo_release_job_creation || error_exit 'Updating monorepo-promote.yaml failed'
+  pe_modules_release_job_creation || error_exit 'Updating pe-modules.yaml failed'
+  pe_installer_promote_release_job_creation || error_exit 'Updating pe_installer-promote.yaml failed'
+  pe_backup_tools_release_job_creation || error_exit 'Updating pe-backup-tools.yaml failed'
+
+  git commit -m "Installer team pipelines for ${PE_VERSION}-release"
   # push changes to upstream and create a PR
   echo 'Pushing changes to upstream...'
   git push origin $TEMP_BRANCH

--- a/vars/bash/release_job_reverts.sh
+++ b/vars/bash/release_job_reverts.sh
@@ -9,7 +9,7 @@ git checkout -b $TEMP_BRANCH
 
 # Search through git logs for the release version
 # Then we only care about the commit SHA
-for i in $(git log --grep="for ${PE_VERSION}-release" --oneline --no-merges | sed "s/\([[:alpha:]]\?[[:digit:]]*\) .*/\1/")
+for i in $(git log --grep="Installer team pipelines for ${PE_VERSION}-release" --oneline --no-merges | sed "s/\([[:alpha:]]\?[[:digit:]]*\) .*/\1/")
 do
     git revert $i --no-edit
 done


### PR DESCRIPTION
This modifies the installer_team_release_creation_job script to work with the recent changes in pe-integration.yaml and pe-modules.yaml, and adds pe-backup-tools and pe_installer. It also changes CODENAME to MAINLINE_BRANCH to add some clarity to what that variable is mostly being used for, changes PE_FAMILY to X_Y for additional clarity, adds some extra comments to the yaml files, sets kickoff times for pipelines and disables mainline CI pipelines (except for main), and all changes are now in a single commit instead of several.