### PR TITLE
(maint) Force push temp branch in move_ci_pipeline_kickoff

### DIFF
--- a/vars/bash/move_ci_pipeline_kickoff.sh
+++ b/vars/bash/move_ci_pipeline_kickoff.sh
@@ -67,7 +67,7 @@ if [[ "${uncommitted}" == "0" ]]; then
 fi
 git commit -m "${commit_message}"
 echo "Pushing ${TEMP_BRANCH}..."
-git push origin "${TEMP_BRANCH}"
+git push -f origin "${TEMP_BRANCH}"
 echo "Creating PR..."
 PULL_REQUEST="$(git show -s --pretty='%s' | hub pull-request -b master -h ${TEMP_BRANCH} -F -)"
 PR_NUM="$(hub pr list -h ${TEMP_BRANCH} -f '%I')"


### PR DESCRIPTION
If a previous PR failed to merge automatically, it would leave the temp branch in place on ci-job-configs, and a subsequent run of this script would fail.  This force pushes the temp branch so even if it already exists, it will be modified for the latest run of the script.