### PR TITLE
(maint) Fix move_ci_pipline_kickoff merge error

### DIFF
--- a/vars/bash/move_ci_pipeline_kickoff.sh
+++ b/vars/bash/move_ci_pipeline_kickoff.sh
@@ -3,7 +3,8 @@
 # Moves PE integration pipeline kickoff time. If HOUR == -1, disables the pipeline instead.
 readonly BRANCH=$1
 readonly HOUR=$2
-readonly TEMP_BRANCH="auto/master/change_PE_CI_time_${BRANCH}"
+readonly CJC_BRANCH="master"
+readonly TEMP_BRANCH="auto/${CJC_BRANCH}/change_PE_CI_time_${BRANCH}"
 
 # Find CI status of the merge PR
 # If hub ci-status returns 2 (status: pending), wait  for another 10 seconds
@@ -47,7 +48,7 @@ rm -rf ./ci-job-configs
 git clone git@github.com:puppetlabs/ci-job-configs ./ci-job-configs
 cd ci-job-configs
 readonly yaml_filepath=./jenkii/enterprise/projects/pe-integration.yaml
-git checkout -b "${TEMP_BRANCH}" origin/master
+git checkout -b "${TEMP_BRANCH}" origin/${CJC_BRANCH}
 if (( $HOUR == -1 )); then
   sed -i "/${BRANCH} pe-integration-non-standard-agents disable anchor/{n;s/False/True/}" $yaml_filepath
   sed -i "/${BRANCH} pe-integration-full disable anchor/{n;s/False/True/}" $yaml_filepath
@@ -62,27 +63,35 @@ fi
 git add $yaml_filepath
 uncommitted=$(git status --porcelain=v1 --untracked-files=no 2>/dev/null | wc -l)
 if [[ "${uncommitted}" == "0" ]]; then
-  echo "No changes to ${yaml_filepath} detected. Check that ${BRANCH} is the correct branch and that the timed_trigger_cron anchor for this branch exists."
+  echo "No changes to ${yaml_filepath} detected. Check that ${BRANCH} is the correct branch and that the timed_trigger_cron anchor for this branch exists. If so, you may be trying to set the time to the value it is already set to."
   exit 1
 fi
 git commit -m "${commit_message}"
 echo "Pushing ${TEMP_BRANCH}..."
 git push -f origin "${TEMP_BRANCH}"
 echo "Creating PR..."
-PULL_REQUEST="$(git show -s --pretty='%s' | hub pull-request -b master -h ${TEMP_BRANCH} -F -)"
+PULL_REQUEST="$(git show -s --pretty='%s' | hub pull-request -b ${CJC_BRANCH} -h ${TEMP_BRANCH} -F -)"
 PR_NUM="$(hub pr list -h ${TEMP_BRANCH} -f '%I')"
 echo "Opened PR: ${PULL_REQUEST}"
 is_ci_status_success ${TEMP_BRANCH}
 CI_STATUS=$?
 if [[ "${CI_STATUS}" -eq "0" ]]; then
-  echo "PR CI status is green. Merging PR."
+  echo "PR CI status is green. Merging PR. You can probably ignore the error that shows up just after this message."
   hub api -XPUT "repos/puppetlabs/ci-job-configs/pulls/${PR_NUM}/merge"
   MERGE_STATUS=$?
-  if [[ "${MERGE_STATUS}" -eq "0" ]]; then
-    echo "PR merge successful. Deleting ${TEMP_BRANCH}."
-    git push origin --delete "${TEMP_BRANCH}"
-    if [[ "${?}" -ne "0" ]]; then
-      echo "Failed to delete ${TEMP_BRANCH} from origin. Please delete manually."
+  # At the moment, hub thinks the merge failed (exit code 22) due to needing a review on the PR,
+  # but it actually merges it just fine, so we'll check that there are no open PRs after the merge.
+  if [[ "${MERGE_STATUS}" -eq "0" ]] || [[ "${MERGE_STATUS}" -eq "22" ]] ; then
+    pr="$(hub pr list -h ${TEMP_BRANCH} -f '%I')"
+    if [[ -z "${pr}" ]]; then
+      echo "PR merge successful. Deleting ${TEMP_BRANCH}."
+      git push origin --delete "${TEMP_BRANCH}"
+      if [[ "${?}" -ne "0" ]]; then
+        echo "Failed to delete ${TEMP_BRANCH} from origin. Please delete manually."
+        exit 1
+      fi
+    else
+      echo "PR ${pr} still appears to be open."
       exit 1
     fi
   else


### PR DESCRIPTION
Because ci-job-configs requires a review on all PRs, when hub tries to hit the merge endpoint, it will think it failed.  However, puppetlabs-jenkins has admin on the repo, and it appears the merge actually does happen. So this allows for the failure exit code, and just double checks that the merge actually happened afterwards.