### PR TITLE
Revert "(maint) Use ABS for pe-installer-shim acceptance"

### DIFF
--- a/vars/run_installer_shim_acceptance.groovy
+++ b/vars/run_installer_shim_acceptance.groovy
@@ -16,7 +16,7 @@ def call(String rubyVersion, String platform, String peFamily) {
     sh "${bundle_exec.bundleExec}"
 
     def acceptance_gems = new BundleInstall(rubyVersion)
-    def generate_beaker_hosts = new BeakerHostgenerator(rubyVersion, "https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/${peFamily}/ci-ready", pe_version, platform, 'abs', 'hosts.cfg')
+    def generate_beaker_hosts = new BeakerHostgenerator(rubyVersion, "https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/${peFamily}/ci-ready", pe_version, platform, 'vmpooler', 'hosts.cfg')
     def run_beaker = new Beaker(rubyVersion, '--xml --debug --root-keys --repo-proxy --hosts hosts.cfg --type pe --keyfile /var/lib/jenkins/.ssh/id_rsa-acceptance --tests tests --preserve-hosts never --pre-suite pre-suite')
 
     sh """#!/bin/bash


### PR DESCRIPTION
Reverts puppetlabs/puppet_jenkins_shared_libraries#92

More work is needed to get ABS to work with Jenkinsfile-based pipelines.  Since this was only to get 2018.1.x working, and since we confirmed it is going away in 10 days, we'll just leave this using vmpooler for the time being.