### PR TITLE
(maint) Fix pe-backup-tools release pipeline

### DIFF
--- a/vars/bash/installer_team_release_creation_job.sh
+++ b/vars/bash/installer_team_release_creation_job.sh
@@ -277,6 +277,7 @@ pe_backup_tools_release_job_creation() {
             p_pkg-int-sys-testing_env-command: |
               export pe_dist_dir=https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/${FAMILY}/release/ci-ready
               export PE_FAMILY=${FAMILY}
+              export \"\$(redis-cli -h redis.delivery.puppetlabs.net get ${FAMILY}_release_pe_version)\"
               eval \"\$(ssh-agent -t 24h -s)\"
               ssh-add \$HOME/.ssh/id_rsa
               ssh-add \$HOME/.ssh/id_rsa-acceptance


### PR DESCRIPTION
The regular pipeline will grab the version from the LATEST file on artifactory, but the release dir doesn't contain this file, so we need to specify pe_ver instead.