### PR TITLE
(maint) Remove Ruby version override in pe_installer-promote

### DIFF
--- a/vars/bash/installer_team_release_creation_job.sh
+++ b/vars/bash/installer_team_release_creation_job.sh
@@ -214,7 +214,6 @@ pe_installer_promote_release_job_creation() {
   echo "
         # ---- ${PE_VERSION}-release ----
         - 'ruby-vanagon-component-pipeline':
-            p_rvm_ruby_version: 'ruby-2.5.1'
             p_component_branch: '${PE_VERSION}-release'
             component_scm_branch: '${PE_VERSION}-release'
             qualifier: '${PE_VERSION}-release'


### PR DESCRIPTION
We should no longer specify the Ruby version to use in the pe_installer-promote pipeline and instead use the default, since 2.5.1 is too old for running specs now.